### PR TITLE
Fix input handling indentation and clean entity classes

### DIFF
--- a/prismalia/input.py
+++ b/prismalia/input.py
@@ -34,13 +34,6 @@ class InputManager:
         if keys[pygame.K_s] or keys[pygame.K_DOWN]:
             self.state.move_y += 1
         if keys[pygame.K_a] or keys[pygame.K_q] or keys[pygame.K_LEFT]:
-
-        if keys[pygame.K_w] or keys[pygame.K_UP]:
-            self.state.move_y -= 1
-        if keys[pygame.K_s] or keys[pygame.K_DOWN]:
-            self.state.move_y += 1
-        if keys[pygame.K_a] or keys[pygame.K_LEFT]:
-
             self.state.move_x -= 1
         if keys[pygame.K_d] or keys[pygame.K_RIGHT]:
             self.state.move_x += 1
@@ -58,9 +51,6 @@ class InputManager:
                 if event.key == pygame.K_f:
                     self.state.feed_animal = True
                 if event.key == pygame.K_l:
-
-                if event.key == pygame.K_q:
-
                     self.state.toggle_logic = True
 
         return self.state


### PR DESCRIPTION
## Summary
- repair indentation issues in the input manager and ensure toggle logic handling uses the correct key
- clean up entity definitions to remove duplicate constructors and unreachable logic

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ccfad66b30832e949c62794c659f69