### PR TITLE
Remove redundant resource blit

### DIFF
--- a/src/engine/tilemap.py
+++ b/src/engine/tilemap.py
@@ -94,12 +94,6 @@ class TileMap:
                     res_rect.midbottom = (draw_x + TILE_WIDTH // 2, draw_y + TILE_HEIGHT)
                     surface.blit(resource_sprite, res_rect)
 
-
-
-                    res_x = draw_x
-                    res_y = draw_y - TILE_HEIGHT // 2
-                    surface.blit(resource_sprite, (res_x, res_y))
-
     def iter_tiles(self) -> Iterable[Tuple[int, int, Tile]]:
         for y in range(self.height):
             for x in range(self.width):


### PR DESCRIPTION
## Summary
- remove the duplicate resource blit in `TileMap.screen_draw` to avoid drawing a resource twice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2eaee24c4832eaf4bc69f67677bf6