### PR TITLE
Fix duplicate entity rendering

### DIFF
--- a/src/engine/entities.py
+++ b/src/engine/entities.py
@@ -27,12 +27,6 @@ class Entity:
         )
         surface.blit(sprite, rect)
 
-
-        draw_x, draw_y = grid_to_screen(self.position.x, self.position.y, *camera_offset)
-        draw_x -= sprite.get_width() // 2
-        draw_y -= sprite.get_height() - sprite.get_height() // 3
-        surface.blit(sprite, (draw_x, draw_y))
-
     def move_towards(self, target: pygame.Vector2, speed: float, dt: float) -> float:
         direction = target - self.position
         distance = direction.length()


### PR DESCRIPTION
## Summary
- remove the redundant draw_x/draw_y blit in Entity.draw so sprites render only once

## Testing
- SDL_VIDEODRIVER=dummy python - <<'PY' ... (single frame render smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68d2ec663dd8832ea417a8bc1873490d