### PR TITLE
Add world serialization and save/load menus

### DIFF
--- a/src/gameplay/inventory.py
+++ b/src/gameplay/inventory.py
@@ -32,3 +32,17 @@ class Inventory:
 
     def items(self) -> Iterable[tuple[str, int]]:
         return self.stacks.items()
+
+    def to_dict(self) -> dict[str, object]:
+        return {"stacks": dict(self.stacks)}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "Inventory":
+        inventory = cls()
+        stacks = data.get("stacks", {}) if isinstance(data, dict) else {}
+        inventory.stacks = {
+            str(resource): int(amount)
+            for resource, amount in stacks.items()
+            if isinstance(resource, str)
+        }
+        return inventory

--- a/src/gameplay/player.py
+++ b/src/gameplay/player.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Any, Tuple
 
 import pygame
 
@@ -56,3 +56,30 @@ class Player(Entity):
             self.selected_block = "campfire"
         else:
             self.selected_block = "wood_block"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": [float(self.position.x), float(self.position.y)],
+            "hunger": float(self.hunger),
+            "selected_block": self.selected_block,
+            "inventory": self.inventory.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Player":
+        position_data = data.get("position", (0.0, 0.0))
+        if isinstance(position_data, (list, tuple)) and len(position_data) >= 2:
+            pos = (float(position_data[0]), float(position_data[1]))
+        else:
+            pos = (0.0, 0.0)
+        player = cls(pos)
+        hunger = data.get("hunger")
+        if hunger is not None:
+            player.hunger = float(hunger)
+        selected_block = data.get("selected_block")
+        if isinstance(selected_block, str):
+            player.selected_block = selected_block
+        inventory_data = data.get("inventory")
+        if isinstance(inventory_data, dict):
+            player.inventory = Inventory.from_dict(inventory_data)
+        return player

--- a/src/main.py
+++ b/src/main.py
@@ -6,8 +6,11 @@ import pygame
 
 from .engine.constants import FPS, WINDOW_HEIGHT, WINDOW_WIDTH
 from .gameplay.world import World
+from .storage import save_manager
 from .ui.command_menu import CommandMenu
 from .ui.hud import HUD
+from .ui.main_menu import MainMenu
+from .ui.pause_menu import PauseMenu
 
 
 def main() -> None:
@@ -16,36 +19,130 @@ def main() -> None:
     pygame.display.set_caption("Prismalia MVP")
     clock = pygame.time.Clock()
 
-    world = World()
-    world.set_surface_size(screen.get_size())
-    hud = HUD()
-    command_menu = CommandMenu()
+    world: World | None = None
+    hud: HUD | None = None
+    command_menu: CommandMenu | None = None
+    main_menu = MainMenu()
+    pause_menu = PauseMenu()
+    state: str = "menu"
 
     running = True
     while running:
         dt = clock.tick(FPS) / 1000.0
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
+                if world is not None:
+                    try:
+                        world.save()
+                    except Exception as error:  # pragma: no cover - best effort logging
+                        print(f"Échec de la sauvegarde du monde: {error}")
                 running = False
                 break
-            if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
-                running = False
+
+            if not running:
                 break
-            if command_menu.handle_event(event, world):
+
+            if state == "menu":
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    running = False
+                    break
+                result = main_menu.handle_event(event)
+                if result:
+                    action, payload = result
+                    if action == "new_world":
+                        slot_value = payload.get("slot_name")
+                        if isinstance(slot_value, str) and slot_value:
+                            slot_name = slot_value
+                        elif slot_value is not None:
+                            slot_name = str(slot_value)
+                        else:
+                            continue
+                        title_value = payload.get("title")
+                        title = title_value if isinstance(title_value, str) else slot_name
+                        seed = payload.get("seed")
+                        seed_int: int | None
+                        if seed is not None:
+                            try:
+                                seed_int = int(seed)
+                            except (TypeError, ValueError):
+                                seed_int = None
+                        else:
+                            seed_int = None
+                        world = World(
+                            slot_name=slot_name,
+                            title=title,
+                            seed=seed_int,
+                        )
+                        world.set_surface_size(screen.get_size())
+                        hud = HUD()
+                        command_menu = CommandMenu()
+                        state = "game"
+                    elif action == "load_world":
+                        slot = payload.get("slot_name")
+                        if not isinstance(slot, str):
+                            continue
+                        try:
+                            world = save_manager.load_world(slot)
+                        except (FileNotFoundError, ValueError) as error:
+                            print(f"Impossible de charger '{slot}': {error}")
+                            main_menu.refresh()
+                            continue
+                        world.set_surface_size(screen.get_size())
+                        hud = HUD()
+                        command_menu = CommandMenu()
+                        state = "game"
                 continue
-            world.handle_event(event)
 
-        keys = pygame.key.get_pressed()
-        world.update(dt, keys)
-        hud.update(dt)
+            if state == "game" and world is not None and command_menu is not None:
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    state = "pause"
+                    continue
+                if command_menu.handle_event(event, world):
+                    continue
+                world.handle_event(event)
+                continue
 
-        message = world.consume_message()
-        if message:
-            hud.set_message(message)
+            if state == "pause":
+                action = pause_menu.handle_event(event)
+                if action == "resume":
+                    state = "game"
+                elif action == "save_quit":
+                    if world is not None:
+                        try:
+                            world.save()
+                        except Exception as error:  # pragma: no cover - best effort logging
+                            print(f"Échec de la sauvegarde du monde: {error}")
+                    world = None
+                    hud = None
+                    command_menu = None
+                    state = "menu"
+                    main_menu.refresh()
+                    main_menu.selection = 0
+                continue
 
-        world.draw(screen)
-        hud.draw(screen, world)
-        command_menu.draw(screen, world)
+        if not running:
+            break
+
+        if state == "menu":
+            main_menu.draw(screen)
+        elif state == "game" and world is not None and hud is not None and command_menu is not None:
+            keys = pygame.key.get_pressed()
+            world.update(dt, keys)
+            hud.update(dt)
+
+            message = world.consume_message()
+            if message:
+                hud.set_message(message)
+
+            world.draw(screen)
+            hud.draw(screen, world)
+            command_menu.draw(screen, world)
+        elif state == "pause" and world is not None and hud is not None and command_menu is not None:
+            hud.update(dt)
+            world.draw(screen)
+            hud.draw(screen, world)
+            command_menu.draw(screen, world)
+            pause_menu.draw(screen)
 
         pygame.display.flip()
 

--- a/src/storage/save_manager.py
+++ b/src/storage/save_manager.py
@@ -1,0 +1,96 @@
+"""Helpers for persisting and loading Prismalia worlds."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+SAVE_DIR = Path("saves")
+
+
+def _ensure_save_dir() -> None:
+    SAVE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def list_worlds() -> List[Dict[str, Any]]:
+    """Return metadata for all available world saves."""
+
+    _ensure_save_dir()
+    saves: List[Dict[str, Any]] = []
+    for path in sorted(SAVE_DIR.glob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            continue
+        metadata = dict(payload.get("metadata", {}))
+        metadata.setdefault("slot_name", path.stem)
+        metadata.setdefault("title", metadata["slot_name"])
+        if "updated_at" not in metadata:
+            metadata["updated_at"] = datetime.utcfromtimestamp(
+                path.stat().st_mtime
+            ).isoformat()
+        if "created_at" not in metadata:
+            metadata["created_at"] = metadata["updated_at"]
+        saves.append(metadata)
+
+    saves.sort(key=lambda meta: meta.get("updated_at", ""), reverse=True)
+    return saves
+
+
+def load_world(slot_name: str) -> "World":
+    """Load a world for the provided save slot."""
+
+    _ensure_save_dir()
+    path = SAVE_DIR / f"{slot_name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"No save found for slot '{slot_name}'")
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    metadata = dict(payload.get("metadata", {}))
+    metadata.setdefault("slot_name", slot_name)
+    data = payload.get("world")
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid save data for slot '{slot_name}'")
+    from ..gameplay.world import World
+
+    return World.from_save(data, metadata)
+
+
+def save_world(world: "World", slot_name: str) -> None:
+    """Persist the provided world in the selected slot."""
+
+    _ensure_save_dir()
+    path = SAVE_DIR / f"{slot_name}.json"
+
+    existing_metadata: Dict[str, Any] = {}
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            existing_metadata = dict(payload.get("metadata", {}))
+        except (OSError, json.JSONDecodeError):
+            existing_metadata = {}
+
+    world_metadata: Dict[str, Any] = {
+        "slot_name": slot_name,
+        "title": getattr(world, "title", slot_name),
+        "seed": int(getattr(world, "seed", 0)) if getattr(world, "seed", None) is not None else None,
+        "size": [world.tilemap.width, world.tilemap.height],
+        "player_position": [float(world.player.position.x), float(world.player.position.y)],
+        "player_hunger": float(world.player.hunger),
+        "animal_hunger": float(world.animal.hunger),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+    world_metadata["created_at"] = existing_metadata.get(
+        "created_at", world_metadata["updated_at"]
+    )
+
+    payload = {
+        "metadata": world_metadata,
+        "world": world.to_dict(),
+    }
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)

--- a/src/ui/main_menu.py
+++ b/src/ui/main_menu.py
@@ -1,0 +1,141 @@
+"""Simple text-based main menu for selecting and creating worlds."""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import pygame
+
+from ..engine.constants import COLOR_PANEL_BORDER, COLOR_TEXT
+from ..storage import save_manager
+
+
+class MainMenu:
+    def __init__(self) -> None:
+        self.title_font = pygame.font.Font(None, 68)
+        self.entry_font = pygame.font.Font(None, 32)
+        self.detail_font = pygame.font.Font(None, 22)
+        self.selection = 0
+        self.worlds: List[Dict[str, Any]] = []
+        self._entry_rects: List[Tuple[pygame.Rect, int]] = []
+        self.refresh()
+
+    def refresh(self) -> None:
+        self.worlds = save_manager.list_worlds()
+        if self.selection > len(self.worlds):
+            self.selection = len(self.worlds)
+
+    def handle_event(self, event: pygame.event.Event) -> Optional[Tuple[str, Dict[str, Any]]]:
+        total_options = len(self.worlds) + 1
+        if event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_UP, pygame.K_w):
+                self.selection = (self.selection - 1) % total_options
+            elif event.key in (pygame.K_DOWN, pygame.K_s):
+                self.selection = (self.selection + 1) % total_options
+            elif event.key == pygame.K_RETURN:
+                return self._activate_selection()
+            elif event.key == pygame.K_r:
+                self.refresh()
+        elif event.type == pygame.MOUSEMOTION:
+            option = self._option_at(event.pos)
+            if option is not None:
+                self.selection = option
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            option = self._option_at(event.pos)
+            if option is not None:
+                self.selection = option
+                return self._activate_selection()
+        return None
+
+    def _option_at(self, pos: Tuple[int, int]) -> Optional[int]:
+        for rect, index in self._entry_rects:
+            if rect.collidepoint(pos):
+                return index
+        return None
+
+    def _activate_selection(self) -> Optional[Tuple[str, Dict[str, Any]]]:
+        if self.selection == 0:
+            return "new_world", self._build_new_world_payload()
+        if 0 < self.selection <= len(self.worlds):
+            metadata = self.worlds[self.selection - 1]
+            return "load_world", metadata
+        return None
+
+    def _build_new_world_payload(self) -> Dict[str, Any]:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        base_name = f"monde-{timestamp}"
+        slot_name = base_name
+        existing = {world.get("slot_name") for world in self.worlds}
+        counter = 1
+        while slot_name in existing:
+            slot_name = f"{base_name}-{counter}"
+            counter += 1
+        seed = random.randrange(0, 2**31)
+        return {
+            "slot_name": slot_name,
+            "title": f"Monde {timestamp}",
+            "seed": seed,
+        }
+
+    def draw(self, surface: pygame.Surface) -> None:
+        surface.fill((16, 18, 28))
+        title = self.title_font.render("Prismalia", True, COLOR_TEXT)
+        title_rect = title.get_rect(center=(surface.get_width() // 2, 120))
+        surface.blit(title, title_rect)
+
+        subtitle = self.entry_font.render("Sélectionnez un monde", True, COLOR_TEXT)
+        subtitle_rect = subtitle.get_rect(center=(surface.get_width() // 2, 180))
+        surface.blit(subtitle, subtitle_rect)
+
+        self._entry_rects = []
+        start_y = 240
+        option_width = 520
+        option_height = 54
+        total_options = len(self.worlds) + 1
+
+        for index in range(total_options):
+            rect = pygame.Rect(
+                surface.get_width() // 2 - option_width // 2,
+                start_y + index * (option_height + 16),
+                option_width,
+                option_height,
+            )
+            is_selected = index == self.selection
+            color = (80, 90, 130, 220) if is_selected else (48, 54, 78, 200)
+            panel = pygame.Surface(rect.size, pygame.SRCALPHA)
+            panel.fill(color)
+            pygame.draw.rect(panel, COLOR_PANEL_BORDER, panel.get_rect(), 2)
+
+            if index == 0:
+                label = self.entry_font.render("+ Nouveau monde", True, COLOR_TEXT)
+                panel.blit(label, (20, panel.get_height() // 2 - label.get_height() // 2))
+            else:
+                metadata = self.worlds[index - 1]
+                title_text = metadata.get("title") or metadata.get("slot_name") or "Monde"
+                label = self.entry_font.render(str(title_text), True, COLOR_TEXT)
+                panel.blit(label, (20, 10))
+                updated = metadata.get("updated_at", "")
+                details = metadata.get("player_hunger")
+                detail_lines = [f"Dernière sauvegarde : {updated}"]
+                if details is not None:
+                    player_hunger = float(details)
+                    animal_hunger = float(metadata.get("animal_hunger", 0.0))
+                    detail_lines.append(
+                        f"Faim joueur : {player_hunger:.0f} | Faim animal : {animal_hunger:.0f}"
+                    )
+                size_meta = metadata.get("size")
+                if isinstance(size_meta, (list, tuple)) and len(size_meta) >= 2:
+                    detail_lines.append(f"Taille : {size_meta[0]} x {size_meta[1]}")
+                for i, line in enumerate(detail_lines):
+                    detail = self.detail_font.render(line, True, COLOR_TEXT)
+                    panel.blit(detail, (20, 28 + i * 18))
+
+            surface.blit(panel, rect)
+            self._entry_rects.append((rect, index))
+
+        hint_text = self.detail_font.render(
+            "Entrée: valider | R: rafraîchir | Échap: quitter", True, COLOR_TEXT
+        )
+        surface.blit(hint_text, (surface.get_width() // 2 - hint_text.get_width() // 2, surface.get_height() - 60))

--- a/src/ui/pause_menu.py
+++ b/src/ui/pause_menu.py
@@ -1,0 +1,77 @@
+"""Overlay menu displayed when the game is paused."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pygame
+
+from ..engine.constants import COLOR_PANEL, COLOR_PANEL_BORDER, COLOR_TEXT
+
+
+class PauseMenu:
+    def __init__(self) -> None:
+        self.title_font = pygame.font.Font(None, 56)
+        self.button_font = pygame.font.Font(None, 32)
+        self._buttons = [
+            ("Reprendre", "resume"),
+            ("Sauvegarder et quitter", "save_quit"),
+        ]
+        self._button_rects: list[tuple[pygame.Rect, str]] = []
+
+    def handle_event(self, event: pygame.event.Event) -> Optional[str]:
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                return "save_quit"
+            if event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                return "resume"
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            for rect, action in self._button_rects:
+                if rect.collidepoint(event.pos):
+                    return action
+        return None
+
+    def draw(self, surface: pygame.Surface) -> None:
+        overlay = pygame.Surface(surface.get_size(), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 160))
+        surface.blit(overlay, (0, 0))
+
+        panel_width = 420
+        panel_height = 260
+        panel_rect = pygame.Rect(
+            (surface.get_width() - panel_width) // 2,
+            (surface.get_height() - panel_height) // 2,
+            panel_width,
+            panel_height,
+        )
+        panel_surface = pygame.Surface(panel_rect.size, pygame.SRCALPHA)
+        panel_surface.fill(COLOR_PANEL)
+        pygame.draw.rect(panel_surface, COLOR_PANEL_BORDER, panel_surface.get_rect(), 2)
+
+        title = self.title_font.render("Pause", True, COLOR_TEXT)
+        title_rect = title.get_rect(center=(panel_rect.width // 2, 60))
+        panel_surface.blit(title, title_rect)
+
+        self._button_rects = []
+        button_width = panel_rect.width - 120
+        button_height = 50
+        start_y = 110
+        mouse_pos = pygame.mouse.get_pos()
+        for index, (label, action) in enumerate(self._buttons):
+            rect = pygame.Rect(
+                (panel_rect.width - button_width) // 2,
+                start_y + index * (button_height + 24),
+                button_width,
+                button_height,
+            )
+            absolute_rect = rect.move(panel_rect.topleft)
+            hovered = absolute_rect.collidepoint(mouse_pos)
+            fill_color = (90, 96, 128, 240) if hovered else (48, 54, 78, 230)
+            pygame.draw.rect(panel_surface, fill_color, rect, border_radius=8)
+            pygame.draw.rect(panel_surface, COLOR_PANEL_BORDER, rect, 2, border_radius=8)
+            text = self.button_font.render(label, True, COLOR_TEXT)
+            text_rect = text.get_rect(center=rect.center)
+            panel_surface.blit(text, text_rect)
+            self._button_rects.append((absolute_rect, action))
+
+        surface.blit(panel_surface, panel_rect)


### PR DESCRIPTION
## Summary
- add save manager for persisting and loading worlds with metadata
- implement serialization helpers on gameplay objects and world loading/saving APIs
- add main menu and pause UI with save-and-quit handling and integrate into the game loop

## Testing
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68d2eff1a704832eb8775f8274a2006d