### PR TITLE
Add main menu state management

### DIFF
--- a/src/gameplay/world.py
+++ b/src/gameplay/world.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import math
+import random
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 import pygame
@@ -14,10 +17,6 @@ from ..engine.constants import (
     WINDOW_HEIGHT,
     WINDOW_WIDTH,
 )
-
-
-
-from ..engine.constants import CAMPFIRE_LIGHT_RADIUS, COLOR_SKY, PLAYER_LIGHT_RADIUS, WINDOW_WIDTH
 from ..engine.isometric import grid_to_screen, screen_to_grid
 from ..engine.tilemap import TileMap
 
@@ -25,12 +24,15 @@ from .animal import Animal
 from .player import Player
 from .resources import BUILDABLE_BLOCKS, RESOURCE_DEFINITIONS, RESOURCE_DISPLAY_NAMES
 
+SAVE_DIR = Path(__file__).resolve().parents[2] / "saves"
+
 
 class World:
-    def __init__(self, size: Tuple[int, int] = (24, 24)) -> None:
+    def __init__(self, size: Tuple[int, int] = (24, 24), *, seed: int | None = None) -> None:
         self.surface_size = (WINDOW_WIDTH, WINDOW_HEIGHT)
         self.tilemap = TileMap(*size)
-        self.tilemap.generate()
+        self.seed = seed if seed is not None else random.randrange(0, 2**31)
+        self.tilemap.generate(self.seed)
         spawn = (size[0] // 2, size[1] // 2)
         self.player = Player((spawn[0] + 0.5, spawn[1] + 0.5))
         self.animal = Animal((spawn[0] + 2, spawn[1] + 0.5))
@@ -38,6 +40,14 @@ class World:
         self.camera_offset = (0.0, 0.0)
         self.message: Optional[str] = None
         self._light_mask_cache: dict[tuple[int, int, int], pygame.Surface] = {}
+
+    @classmethod
+    def new(
+        cls, seed: int | None = None, size: Tuple[int, int] = (24, 24)
+    ) -> "World":
+        """Factory creating a freshly generated world."""
+
+        return cls(size=size, seed=seed)
 
     def set_surface_size(self, size: Tuple[int, int]) -> None:
         self.surface_size = size
@@ -192,3 +202,84 @@ class World:
         message = self.message
         self.message = None
         return message
+
+
+def _ensure_save_dir() -> Path:
+    SAVE_DIR.mkdir(parents=True, exist_ok=True)
+    return SAVE_DIR
+
+
+def list_saved_worlds() -> List[str]:
+    """Return the identifiers of available saved worlds."""
+
+    directory = _ensure_save_dir()
+    saves = [path.stem for path in directory.glob("*.json")]
+    return sorted(saves)
+
+
+def load_world(identifier: str | Path) -> World:
+    """Load a world from disk using a simple JSON representation."""
+
+    directory = _ensure_save_dir()
+    path = Path(identifier)
+    if not path.is_absolute():
+        path = directory / path
+    if path.is_dir():
+        path = path / "world.json"
+    if path.suffix != ".json":
+        path = path.with_suffix(".json")
+    if not path.exists():
+        raise FileNotFoundError(f"No saved world found for '{identifier}'.")
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    size_data = data.get("size")
+    if isinstance(size_data, (list, tuple)) and len(size_data) == 2:
+        size = (int(size_data[0]), int(size_data[1]))
+    else:
+        size = (24, 24)
+    seed = data.get("seed")
+
+    world = World(size=size, seed=seed)
+
+    player_pos = data.get("player_position")
+    if isinstance(player_pos, (list, tuple)) and len(player_pos) == 2:
+        world.player.position.update(float(player_pos[0]), float(player_pos[1]))
+
+    animal_pos = data.get("animal_position")
+    if isinstance(animal_pos, (list, tuple)) and len(animal_pos) == 2:
+        world.animal.position.update(float(animal_pos[0]), float(animal_pos[1]))
+
+    inventory = data.get("inventory")
+    if isinstance(inventory, dict):
+        world.player.inventory.stacks = {
+            str(resource): int(amount) for resource, amount in inventory.items()
+        }
+
+    selected_block = data.get("selected_block")
+    if isinstance(selected_block, str):
+        world.player.selected_block = selected_block
+
+    campfires = data.get("campfires")
+    if isinstance(campfires, list):
+        parsed_campfires: List[pygame.Vector2] = []
+        for item in campfires:
+            if isinstance(item, (list, tuple)) and len(item) == 2:
+                try:
+                    parsed_campfires.append(
+                        pygame.Vector2(float(item[0]), float(item[1]))
+                    )
+                except (TypeError, ValueError):
+                    continue
+        world.campfires = parsed_campfires
+
+    player_hunger = data.get("player_hunger")
+    if isinstance(player_hunger, (int, float)):
+        world.player.hunger = float(player_hunger)
+
+    animal_hunger = data.get("animal_hunger")
+    if isinstance(animal_hunger, (int, float)):
+        world.animal.hunger = float(animal_hunger)
+
+    return world

--- a/src/main.py
+++ b/src/main.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Literal, Optional
+
 import pygame
 
 from .engine.constants import FPS, WINDOW_HEIGHT, WINDOW_WIDTH
-from .gameplay.world import World
+from .gameplay.world import World, load_world, list_saved_worlds
 from .ui.command_menu import CommandMenu
 from .ui.hud import HUD
+from .ui.main_menu import MainMenu
 
 
 def main() -> None:
@@ -16,36 +19,90 @@ def main() -> None:
     pygame.display.set_caption("Prismalia MVP")
     clock = pygame.time.Clock()
 
-    world = World()
-    world.set_surface_size(screen.get_size())
     hud = HUD()
     command_menu = CommandMenu()
 
+    world: Optional[World] = None
+    state: Literal["menu", "playing"] = "menu"
     running = True
+
+    def reset_ui_state() -> None:
+        command_menu.visible = False
+        command_menu.pending = None
+        command_menu.sequence.clear()
+        command_menu.status_text = ""
+        hud.message = ""
+        hud.message_timer = 0.0
+
+    def start_world(new_world: World) -> None:
+        nonlocal world, state
+        world = new_world
+        world.set_surface_size(screen.get_size())
+        reset_ui_state()
+        state = "playing"
+        main_menu.close()
+
+    def handle_new_world(seed: int | None) -> None:
+        start_world(World.new(seed))
+
+    def handle_load_world(identifier: str) -> None:
+        try:
+            loaded_world = load_world(identifier)
+        except FileNotFoundError:
+            main_menu.set_status(f"Sauvegarde '{identifier}' introuvable")
+            main_menu.set_saves(list_saved_worlds())
+            return
+        start_world(loaded_world)
+
+    def handle_quit() -> None:
+        nonlocal running
+        running = False
+
+    main_menu = MainMenu(
+        on_new_world=handle_new_world,
+        on_load_world=handle_load_world,
+        on_quit=handle_quit,
+    )
+    main_menu.open(list_saved_worlds())
+
     while running:
         dt = clock.tick(FPS) / 1000.0
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
                 break
-            if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
-                running = False
-                break
-            if command_menu.handle_event(event, world):
-                continue
-            world.handle_event(event)
 
-        keys = pygame.key.get_pressed()
-        world.update(dt, keys)
-        hud.update(dt)
+            if state == "menu":
+                if main_menu.handle_event(event):
+                    continue
+            elif state == "playing":
+                assert world is not None
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    state = "menu"
+                    main_menu.open(list_saved_worlds())
+                    continue
+                if command_menu.handle_event(event, world):
+                    continue
+                world.handle_event(event)
 
-        message = world.consume_message()
-        if message:
-            hud.set_message(message)
+        if not running:
+            break
 
-        world.draw(screen)
-        hud.draw(screen, world)
-        command_menu.draw(screen, world)
+        if state == "menu":
+            screen.fill((10, 12, 20))
+            main_menu.draw(screen)
+        elif state == "playing" and world is not None:
+            keys = pygame.key.get_pressed()
+            world.update(dt, keys)
+            hud.update(dt)
+
+            message = world.consume_message()
+            if message:
+                hud.set_message(message)
+
+            world.draw(screen)
+            hud.draw(screen, world)
+            command_menu.draw(screen, world)
 
         pygame.display.flip()
 

--- a/src/ui/main_menu.py
+++ b/src/ui/main_menu.py
@@ -1,0 +1,198 @@
+"""Main menu overlay handling game navigation."""
+
+from __future__ import annotations
+
+import random
+from typing import Callable, Sequence
+
+import pygame
+
+from ..engine.constants import COLOR_PANEL, COLOR_PANEL_BORDER, COLOR_TEXT
+
+MenuCallback = Callable[[], None]
+NewWorldCallback = Callable[[int | None], None]
+LoadWorldCallback = Callable[[str], None]
+
+
+class MainMenu:
+    """Simple keyboard-driven main menu for the prototype."""
+
+    def __init__(
+        self,
+        *,
+        on_new_world: NewWorldCallback,
+        on_load_world: LoadWorldCallback,
+        on_quit: MenuCallback,
+    ) -> None:
+        self.on_new_world = on_new_world
+        self.on_load_world = on_load_world
+        self.on_quit = on_quit
+
+        self.selection = 0
+        self.mode: str = "root"
+        self.active = False
+        self.saves: list[str] = []
+        self.status_message: str = ""
+        self.random = random.Random()
+
+        self.title_font = pygame.font.Font(None, 54)
+        self.option_font = pygame.font.Font(None, 30)
+        self.small_font = pygame.font.Font(None, 22)
+
+    # ------------------------------------------------------------------ state
+    def set_saves(self, saves: Sequence[str]) -> None:
+        self.saves = list(saves)
+        self._clamp_selection()
+
+    def open(self, saves: Sequence[str] | None = None) -> None:
+        """Show the menu and optionally refresh the available saves."""
+
+        if saves is not None:
+            self.set_saves(saves)
+        self.selection = 0
+        self.mode = "root"
+        self.active = True
+        self.status_message = ""
+        self._clamp_selection()
+
+    def close(self) -> None:
+        self.active = False
+
+    def set_status(self, message: str) -> None:
+        self.status_message = message
+
+    # ---------------------------------------------------------------- controls
+    def handle_event(self, event: pygame.event.Event) -> bool:
+        if not self.active:
+            return False
+
+        if event.type == pygame.KEYDOWN:
+            if event.key in (pygame.K_UP, pygame.K_w):
+                self._move_selection(-1)
+                return True
+            if event.key in (pygame.K_DOWN, pygame.K_s):
+                self._move_selection(1)
+                return True
+            if event.key in (pygame.K_RETURN, pygame.K_KP_ENTER, pygame.K_SPACE):
+                self._activate_selection()
+                return True
+            if event.key == pygame.K_ESCAPE:
+                if self.mode == "load":
+                    self.mode = "root"
+                    self.selection = 1 if self.saves else 0
+                    self._clamp_selection()
+                else:
+                    self.on_quit()
+                return True
+
+        return False
+
+    # ----------------------------------------------------------------- drawing
+    def draw(self, surface: pygame.Surface) -> None:
+        if not self.active:
+            return
+
+        options = self._current_options()
+        self._clamp_selection()
+
+        overlay = pygame.Surface(surface.get_size(), pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 140))
+        surface.blit(overlay, (0, 0))
+
+        option_area = max(1, len(options)) * 40
+        if self.mode == "load" and not self.saves:
+            option_area += 30
+        panel_width = 520
+        panel_height = 170 + option_area
+        panel_surface = pygame.Surface((panel_width, panel_height), pygame.SRCALPHA)
+        panel_surface.fill(COLOR_PANEL)
+        pygame.draw.rect(panel_surface, COLOR_PANEL_BORDER, panel_surface.get_rect(), 1)
+
+        title = self.title_font.render("Prismalia", True, COLOR_TEXT)
+        panel_surface.blit(title, (32, 26))
+
+        subtitle_text = "Menu principal" if self.mode == "root" else "Charger une sauvegarde"
+        subtitle = self.small_font.render(subtitle_text, True, COLOR_TEXT)
+        panel_surface.blit(subtitle, (34, 80))
+
+        y = 120
+        for index, label in enumerate(options):
+            selected = index == self.selection
+            color = COLOR_TEXT if not selected else (255, 255, 255)
+            text = self.option_font.render(label, True, color)
+            panel_surface.blit(text, (74, y))
+            if selected:
+                indicator = self.option_font.render("▶", True, color)
+                panel_surface.blit(indicator, (40, y))
+            y += 40
+
+        if self.mode == "load" and not self.saves:
+            info = self.small_font.render(
+                "Aucune sauvegarde disponible", True, COLOR_TEXT
+            )
+            panel_surface.blit(info, (74, y))
+            y += 30
+
+        if self.status_message:
+            status = self.small_font.render(self.status_message, True, COLOR_TEXT)
+            panel_surface.blit(status, (34, panel_height - 70))
+
+        hint = self.small_font.render(
+            "↑/↓ pour naviguer · Entrée pour valider · Échap pour quitter",
+            True,
+            COLOR_TEXT,
+        )
+        hint_rect = hint.get_rect()
+        hint_rect.bottomleft = (34, panel_height - 28)
+        panel_surface.blit(hint, hint_rect)
+
+        panel_rect = panel_surface.get_rect(center=surface.get_rect().center)
+        surface.blit(panel_surface, panel_rect.topleft)
+
+    # ----------------------------------------------------------------- helpers
+    def _move_selection(self, delta: int) -> None:
+        count = len(self._current_options())
+        if count == 0:
+            self.selection = 0
+            return
+        self.selection = (self.selection + delta) % count
+
+    def _activate_selection(self) -> None:
+        if self.mode == "root":
+            if self.selection == 0:
+                seed = self.random.randrange(0, 2**31)
+                self.on_new_world(seed)
+            elif self.selection == 1:
+                if self.saves:
+                    self.mode = "load"
+                    self.selection = 0
+                else:
+                    self.set_status("Aucune sauvegarde détectée")
+            elif self.selection == 2:
+                self.on_quit()
+        elif self.mode == "load":
+            if self.selection < len(self.saves):
+                self.on_load_world(self.saves[self.selection])
+            else:
+                self.mode = "root"
+                self.selection = 1 if self.saves else 0
+        self._clamp_selection()
+
+    def _clamp_selection(self) -> None:
+        count = len(self._current_options())
+        if count == 0:
+            self.selection = 0
+        else:
+            self.selection = max(0, min(self.selection, count - 1))
+
+    def _current_options(self) -> list[str]:
+        if self.mode == "root":
+            return [
+                "Nouveau monde",
+                "Charger une sauvegarde",
+                "Quitter",
+            ]
+
+        options = list(self.saves)
+        options.append("Retour")
+        return options


### PR DESCRIPTION
## Summary
- add a dedicated MainMenu UI component to drive navigation
- extend the world module with factory/helpers for spawning and loading worlds
- refactor the main loop to support menu/playing states and world selection

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d2eff242f8832ea503a3a0b6ae83fe